### PR TITLE
Personailzed template form

### DIFF
--- a/src/Form/PersonalizedTemplateType.php
+++ b/src/Form/PersonalizedTemplateType.php
@@ -6,22 +6,53 @@ namespace Lle\HermesBundle\Form;
 
 use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Lle\CruditBundle\Form\Type\GroupType;
+use Lle\HermesBundle\Service\MultiTenantManager;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class PersonalizedTemplateType extends AbstractType
 {
+    public function __construct(
+        protected MultiTenantManager $multiTenantManager
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $builder->add('groupInformations', GroupType::class, [
+            'label' => 'field.group.template_informations',
+            'inherit_data' => true,
+        ])
+            ->add('libelle', TextType::class, [
+                'attr' => ['class' => 'col-md-6'],
+            ])
+            ->add('code', TextType::class, [
+                'attr' => ['class' => 'col-md-6'],
+            ])
+            ->add('senderName', TextType::class, [
+                'attr' => ['class' => 'col-md-6'],
+            ])
+            ->add('senderEmail', EmailType::class, [
+                'attr' => ['class' => 'col-md-6'],
+            ]);
+
         $builder->add('groupContent', GroupType::class, [
             'label' => 'field.group.template_content',
             'inherit_data' => true,
         ])
             ->add('subject', TextType::class)
             ->add('html', CKEditorType::class, [
-                'config' => ['toolbar' => 'full'],
+                'config' => [
+                    'toolbar' => 'full',
+                    'fullPage' => true,
+                    'allowedContent' => true,
+                    'versionCheck' => false
+                ],
                 'label' => false,
                 'attr' => [
                     'rows' => 20,
@@ -31,6 +62,32 @@ class PersonalizedTemplateType extends AbstractType
                 'attr' => [
                     'rows' => 20,
                 ],
+            ]);
+        $builder->add('groupOptions', GroupType::class, [
+            'label' => 'field.group.template_options',
+            'inherit_data' => true,
+        ])
+            ->add('unsubscriptions', CheckboxType::class, [
+                "required" => false,
+                "label" => "field.unsubscriptions",
+                "translation_domain" => "LleHermesBundle",
+            ])
+            ->add('statistics', CheckboxType::class, [
+                "required" => false,
+                "label" => "field.statistics",
+                "translation_domain" => "LleHermesBundle",
+            ])
+            ->add('sendToErrors', CheckboxType::class, [
+                'required' => false,
+                'label' => 'field.sendtoerrors',
+            ])
+            ->add('customBounceEmail', TextType::class, [
+                'required' => false,
+                'label' => 'field.custombounceemail',
+            ])
+            ->add('tenantId', HiddenType::class, [
+                'data' => $this->multiTenantManager->getTenantId(),
+                'label' => false
             ]);
     }
 

--- a/src/Service/Mailer.php
+++ b/src/Service/Mailer.php
@@ -24,7 +24,7 @@ class Mailer
     /**
      * @throws TemplateNotFoundException
      */
-    public function create(MailDto $mail, string $status = Mail::STATUS_SENDING, int $tenantId = null): void
+    public function create(MailDto $mail, string $status = Mail::STATUS_SENDING, ?int $tenantId = null): void
     {
         $template = null;
         if ($this->multiTenantManager->isMultiTenantEnabled()) {


### PR DESCRIPTION
Le personalized template avait moins de champs que le template type. 
avec le besoin d'envoyer des newsletter depuis le tenant il faut avoir accès a tous les champs + un hidden type avec le tenant